### PR TITLE
Fix Selectors Module example

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -319,10 +319,10 @@ StructUtils includes a `Selectors` module that provides a powerful way to query 
 using StructUtils.Selectors
 
 # Create a nested structure
-data = Dict("users" => [
+data = Dict("users" => List([
     Dict("id" => 1, "name" => "Alice"),
     Dict("id" => 2, "name" => "Bob")
-])
+]))
 
 # Query with selectors
 users = data["users"]  # Get the users array


### PR DESCRIPTION
Fixes the below error by using `List`:

```julia-repl
julia> names = users[:].name  # Get all user names
ERROR: type Array has no field name
Stacktrace:
 [1] getproperty(x::Vector{Dict{String, Any}}, f::Symbol)
   @ Base ./Base.jl:49
 [2] top-level scope
   @ REPL[6]:1
```