### PR TITLE
Avoid recursive root lowering in make

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -226,17 +226,29 @@ The `make` function follows these steps:
    - Regular struct (default constructor)
    - Primitive type (requiring a `lift` function)
 
-2. **Object Construction**:
+2. **Root Source Conversion**:
+   - Call `lower` once when the root source is not struct-like
+   - Traverse a struct-like root directly
+
+3. **Object Construction**:
    - For dictionary-like types: Create an empty dictionary and add key-value pairs
    - For array-like types: Create an empty array and push values
    - For no-arg types: Create an empty instance and set fields
    - For regular structs: Collect field values and call the constructor
    - For primitive types: Use `lift` to convert the source value
 
-3. **Field Mapping**:
+4. **Field Mapping**:
    - Match source keys to target fields, respecting field tags
    - Convert values to appropriate field types
    - Handle missing values, defaults, and special types
+
+`applyeach` calls `lower` on nested values in both cases. A `lower` method for
+a struct-like type may therefore call `make` to reuse its field traversal:
+
+```julia
+StructUtils.lower(style::MyStyle, x::MyStruct) =
+    StructUtils.make(Dict{String,Any}, x, style)
+```
 
 ## Implementing StructUtils Interfaces
 
@@ -526,4 +538,3 @@ StructUtils.jl provides a comprehensive suite of tools for working with Julia st
    - Field metadata (`fielddefaults`, `fieldtags`, etc.)
 
 StructUtils.jl integrates well with other packages like JSON.jl for seamless serialization and deserialization of complex Julia types.
-

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -347,6 +347,11 @@ Domain value transformation function. This function is called by
 calling the apply function. By default, `lower` is the identity function.
 This allows a domain transformation of values according to the
 style used.
+
+When [`StructUtils.make`](@ref) uses a structural or container builder, it
+also calls `lower` once on a root source that is not struct-like. Struct-like
+root sources are traversed directly, so their `lower` methods may call `make`
+to reuse its field mapping without recursion.
 """
 function lower end
 
@@ -813,6 +818,11 @@ the automatic "all argument" constructor that structs have defined by default (e
 `make` calls `applyeach` on the `source` object, where the key-value pairs
 from `source` will be used in constructing `T`.
 
+Before structural construction, `make` calls [`StructUtils.lower`](@ref) on a
+root source for which [`StructUtils.structlike`](@ref) is `false`. Struct-like
+root sources are traversed directly. `applyeach` still lowers their nested
+values.
+
 The 3rd definition takes a `style` argument, allowing for overloads of non-owned types `T`.
 The main difference between this and the 2nd definition is that the 3rd definition allows for
 the `make` function to return a tuple of the constructed struct and any side-effect state
@@ -846,6 +856,12 @@ end
 # already satisfies the abstract type we must preserve it instead of rebuilding.
 @inline abstractcollectionpassthrough(style::StructStyle, ::Type{T}, source) where {T} =
     isabstracttype(T) && source isa T && (dictlike(style, T) || arraylike(style, T))
+
+# Non-struct sources opt into representation lowering at the root. Structural
+# sources stay intact so a custom `lower` method can call `make` to traverse
+# their fields without immediately calling itself again.
+@inline _lowerrootsource(style::StructStyle, source) =
+    structlike(style, source) ? source : lower(style, source)
 
 # Keep normal `make` dispatch at the public boundary so exact custom methods
 # and `@choosetype` methods win first. The concrete `Val{T}` token then gives
@@ -966,23 +982,23 @@ function make(style::StructStyle, ::Type{T}, source) where {T}
         end
     end
     if T <: Tuple
-        return maketuple(style, T, lower(style, source))
+        return maketuple(style, T, _lowerrootsource(style, source))
     elseif dictlike(style, T)
-        lowered = lower(style, source)
+        lowered = _lowerrootsource(style, source)
         if abstractcollectionpassthrough(style, T, lowered)
             return lowered, defaultstate(style)
         end
         return makedict(style, T, lowered)
     elseif arraylike(style, T)
-        lowered = lower(style, source)
+        lowered = _lowerrootsource(style, source)
         if abstractcollectionpassthrough(style, T, lowered)
             return lowered, defaultstate(style)
         end
         return makearray(style, T, lowered)
     elseif noarg(style, T)
-        return makenoarg(style, T, lower(style, source))
+        return makenoarg(style, T, _lowerrootsource(style, source))
     elseif structlike(style, T)
-        return makestruct(style, T, lower(style, source))
+        return makestruct(style, T, _lowerrootsource(style, source))
     else
         return lift(style, T, source)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -450,6 +450,19 @@ end
     @test StructUtils.make(NonStructMapping, mapping).value === mapping
 end
 
+@testset "struct-like lower may call make: #66" begin
+    style = RecursiveLowerStyle()
+    value = RecursiveLowerRoot(RecursiveLowerLeaf(2), "root")
+    expected = Dict{String,Any}(
+        "leaf" => Dict{String,Any}("value" => 2),
+        "label" => "root",
+    )
+
+    @test StructUtils.lower(style, value) == expected
+    @test StructUtils.make(style, Dict{String,Any}, value) == (expected, nothing)
+    @test StructUtils.make(Dict{String,Any}, value, style) == expected
+end
+
 @testset "Set make: #13" begin
     @test StructUtils.make(Set{Symbol}, Any["FACTOR"]) == Set{Symbol}([:FACTOR])
 end

--- a/test/struct.jl
+++ b/test/struct.jl
@@ -278,6 +278,25 @@ function StructUtils.make(
     return NonStructCustomMakeTarget(true), StructUtils.defaultstate(style)
 end
 
+struct RecursiveLowerStyle <: StructUtils.StructStyle end
+
+struct RecursiveLowerLeaf
+    value::Int
+end
+
+struct RecursiveLowerRoot
+    leaf::RecursiveLowerLeaf
+    label::String
+end
+
+function StructUtils.lower(
+    style::RecursiveLowerStyle,
+    value::Union{RecursiveLowerLeaf,RecursiveLowerRoot},
+)
+    result, _ = StructUtils.make(style, Dict{String,Any}, value)
+    return result
+end
+
 struct Q
     id::Int
     value::MIME


### PR DESCRIPTION
## Summary

- Limit automatic root lowering to sources for which `structlike(style, source)` is `false`.
- Preserve the `@nonstruct` root mapping added by #64.
- Allow struct-like `lower` methods to call `make` for field traversal without recursion.
- Document the root-lowering contract and add nested regression coverage.

## Root cause

PR #64 made the generic structural `make` path call `lower` for every root source. A struct-like `lower` method implemented with `make` therefore entered a direct `make -> lower -> make` cycle.

The fix keeps root representation lowering for non-struct sources, which is the case required by #29, while traversing ordinary struct roots directly. `applyeach` continues to lower nested values.

## Validation

- Julia 1.9.4: full package suite passed, 255 tests.
- Julia 1.12.6: full package suite passed, 255 tests.
- Julia 1.12.6: JuliaC trim suite passed, 7 checks.
- Julia 1.13.0-rc1: full package suite passed, 255 tests.
- Documenter build and doctests passed.
- Focused four-field struct-to-dictionary check retained 576 bytes per call and showed no measured slowdown.

Fixes #66

Co-authored by Codex