### PR TITLE
Delete unnecessary `eltype()` method

### DIFF
--- a/src/selectors.jl
+++ b/src/selectors.jl
@@ -32,7 +32,6 @@ items(x::List) = getfield(x, :items)
 Base.getindex(x::List) = map(getindex, items(x))
 List(T=Any) = List(T[])
 Base.size(x::List) = size(items(x))
-Base.eltype(::List{T}) where {T} = T
 Base.isassigned(x::List, args::Integer...) = isassigned(items(x), args...)
 
 Base.push!(x::List, item) = push!(items(x), item)


### PR DESCRIPTION
This already has a generic definition in Base: https://github.com/JuliaLang/julia/blob/release-1.13/base/abstractarray.jl#L245-L246

Fixes these invalidations seen on 1.13:
```julia
 inserting eltype(::StructUtils.Selectors.List{T}) where T @ StructUtils.Selectors ~/.julia/packages/StructUtils/019BB/src/selectors.jl:35 invalidated:
   backedges: 1: superseding eltype(x) @ Base abstractarray.jl:245 with MethodInstance for eltype(::Union{ForwardDiff.Dual{T, V, P}, AbstractArray{<:ForwardDiff.Dual{T, V, P}}} where {T, V, P}) (3 children)
              2: superseding eltype(x) @ Base abstractarray.jl:245 with MethodInstance for eltype(::Union{Number, AbstractArray}) (78 children)
              3: superseding eltype(x) @ Base abstractarray.jl:245 with MethodInstance for eltype(::AbstractArray{<:Complex}) (120 children)
              4: superseding eltype(x) @ Base abstractarray.jl:245 with MethodInstance for eltype(::AbstractArray) (497 children)
```