### PR TITLE
Support lazily initialized fields

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,16 +7,19 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [weakdeps]
+LazilyInitializedFields = "0e77f7df-68c5-4e49-93ce-4cd80f5598bf"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [extensions]
+StructUtilsLazilyInitializedFieldsExt = ["LazilyInitializedFields"]
 StructUtilsMeasurementsExt = ["Measurements"]
 StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
 StructUtilsTablesExt = ["Tables"]
 
 [compat]
+LazilyInitializedFields = "1"
 Measurements = "2"
 StaticArraysCore = "1"
 Tables = "1"
@@ -24,6 +27,7 @@ julia = "1.9"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+LazilyInitializedFields = "0e77f7df-68c5-4e49-93ce-4cd80f5598bf"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
@@ -32,4 +36,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Dates", "Measurements", "StaticArrays", "StaticArraysCore", "Tables", "Test", "UUIDs"]
+test = ["Dates", "LazilyInitializedFields", "Measurements", "StaticArrays", "StaticArraysCore", "Tables", "Test", "UUIDs"]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -215,6 +215,64 @@ nt = StructUtils.make(NamedTuple, user)
 user = JSON.parse(json_string, User)  # Uses StructUtils.make under the hood
 ```
 
+### Parametric Types
+
+Use a concrete target when its type parameters are known:
+
+```julia
+struct Box{T}
+    value::T
+end
+
+box = StructUtils.make(Box{Int}, Dict("value" => 1))
+```
+
+An unparameterized target also works when its constructor can infer every type
+parameter from the converted field values:
+
+```julia
+inferred = StructUtils.make(Box, Dict("value" => 1))
+@assert inferred isa Box{Int}
+```
+
+Use a concrete target or a `choosetype` tag when constructor inference cannot
+determine every parameter.
+
+### Lazily Initialized Fields
+
+When
+[`LazilyInitializedFields.jl`](https://github.com/KristofferC/LazilyInitializedFields.jl)
+is loaded, its lazy fields can be omitted from a source. StructUtils initializes
+each omitted lazy field with `uninit`. Present values are converted to the
+field's logical type, including nested structs and parametric types.
+
+```julia
+using LazilyInitializedFields
+
+struct Entry{T}
+    value::T
+end
+
+@lazy struct Cache{T}
+    id::T
+    @lazy entry::Entry{T}
+end
+
+empty_cache = StructUtils.make(Cache{Int}, Dict("id" => 1))
+@assert !isinit(empty_cache, :entry)
+
+loaded_cache = StructUtils.make(
+    Cache,
+    Dict("id" => 1, "entry" => Dict("value" => 2)),
+)
+@assert loaded_cache isa Cache{Int}
+@assert loaded_cache.entry == Entry{Int}(2)
+```
+
+An explicit StructUtils field default takes precedence over `uninit`.
+Outbound conversion still treats `uninit` as a defined field value and includes
+it in the destination.
+
 ### How `make` Works
 
 The `make` function follows these steps:

--- a/ext/StructUtilsLazilyInitializedFieldsExt.jl
+++ b/ext/StructUtilsLazilyInitializedFieldsExt.jl
@@ -1,0 +1,36 @@
+module StructUtilsLazilyInitializedFieldsExt
+
+using StructUtils
+using LazilyInitializedFields: islazyfield, uninit
+
+const Uninitialized = typeof(uninit)
+
+@inline function StructUtils._unionmember(
+    style::StructUtils.StructStyle,
+    ::Type{T},
+    ::Type{Uninitialized},
+    @nospecialize(source),
+) where {T}
+    source isa Uninitialized && return Uninitialized
+
+    logical = Base.typesplit(Base.unwrap_unionall(T), Uninitialized)
+    if logical <: Union{Missing,Nothing} && !StructUtils.nulllike(style, source)
+        throw(ArgumentError("cannot construct lazy field type `$T` from non-null source"))
+    end
+    return logical
+end
+
+@inline function StructUtils._missingfield(
+    ::StructUtils.StructStyle,
+    T::Type,
+    key::Symbol,
+    defaults::NamedTuple,
+)
+    haskey(defaults, key) && return defaults[key]
+    if applicable(islazyfield, T, key) && islazyfield(T, key)
+        return uninit
+    end
+    return nothing
+end
+
+end # module

--- a/src/StructUtils.jl
+++ b/src/StructUtils.jl
@@ -1000,6 +1000,48 @@ end
 @inline _lowerrootsource(style::StructStyle, source) =
     structlike(style, source) ? source : lower(style, source)
 
+# Optional integrations can select a target when one member of a Union has
+# package-specific meaning. Returning `nothing` leaves the normal Union
+# disambiguation unchanged.
+@inline _unionmember(
+    ::StructStyle,
+    ::Type{T},
+    ::Type{M},
+    @nospecialize(source),
+) where {T,M} = nothing
+
+@inline _unionbody(T::Type) = T isa UnionAll ? Base.unwrap_unionall(T) : T
+@inline _isuniontype(T::Type) = _unionbody(T) isa Union
+@inline _rewrapunionmember(T::Type, member) =
+    T isa UnionAll ? Base.rewrap_unionall(member, T) : member
+
+@inline function _specialuniontype(style::StructStyle, ::Type{T}, source) where {T}
+    for member in Base.uniontypes(_unionbody(T))
+        selected = _unionmember(style, T, member, source)
+        selected === nothing || return _rewrapunionmember(T, selected)
+    end
+    return nothing
+end
+
+@inline function _uniontype(style::StructStyle, ::Type{T}, source) where {T}
+    arr_type = nothing
+    scalar_type = nothing
+    for member in Base.uniontypes(_unionbody(T))
+        if arraylike(style, member)
+            arr_type === nothing || return nothing
+            arr_type = member
+        else
+            scalar_type === nothing || return nothing
+            scalar_type = member
+        end
+    end
+    if arr_type !== nothing && scalar_type !== nothing
+        selected = arraylike(style, source) ? arr_type : scalar_type
+        return _rewrapunionmember(T, selected)
+    end
+    return nothing
+end
+
 # Keep normal `make` dispatch at the public boundary so exact custom methods
 # and `@choosetype` methods win first. The concrete `Val{T}` token then gives
 # the default implementation a specialized signature even when `T` is a
@@ -1013,6 +1055,10 @@ function _make(style::StructStyle, ::Val{T}, source, tags) where {T}
         return make(style, tags.choosetype(source), source, _delete(tags, :choosetype))
     end
     if T !== Any
+        if _isuniontype(T)
+            selected = _specialuniontype(style, T, source)
+            selected === nothing || return make(style, selected, source, tags)
+        end
         if T >: Missing && T !== Missing
             if nulllike(style, source)
                 return make(style, Missing, source, tags)
@@ -1026,37 +1072,9 @@ function _make(style::StructStyle, ::Val{T}, source, tags) where {T}
                 return make(style, Base.nonnothingtype(T), source, tags)
             end
         end
-        # for Union types like Union{T, Vector{T}} (after Nothing/Missing have been peeled),
-        # we can disambiguate by checking if source is arraylike;
-        # only applies when there's exactly one arraylike and one non-arraylike member
-        if T isa Union
-            types = Base.uniontypes(T)
-            arr_type = nothing
-            scalar_type = nothing
-            ambiguous = false
-            for t in types
-                if arraylike(style, t)
-                    # more than one arraylike type means we can't disambiguate
-                    if arr_type !== nothing
-                        ambiguous = true
-                        break
-                    end
-                    arr_type = t
-                else
-                    if scalar_type !== nothing
-                        ambiguous = true
-                        break
-                    end
-                    scalar_type = t
-                end
-            end
-            if !ambiguous && arr_type !== nothing && scalar_type !== nothing
-                if arraylike(style, source)
-                    return make(style, arr_type, source, tags)
-                else
-                    return make(style, scalar_type, source, tags)
-                end
-            end
+        if _isuniontype(T)
+            selected = _uniontype(style, T, source)
+            selected === nothing || return make(style, selected, source, tags)
         end
     end
     if T <: Tuple || dictlike(style, T) || arraylike(style, T) || noarg(style, T) || structlike(style, T)
@@ -1072,6 +1090,10 @@ function make(style::StructStyle, ::Type{T}, source) where {T}
     end
     # start with some hard-coded Union cases
     if T !== Any
+        if _isuniontype(T)
+            selected = _specialuniontype(style, T, source)
+            selected === nothing || return make(style, selected, source)
+        end
         if T >: Missing && T !== Missing
             if nulllike(style, source)
                 return make(style, Missing, source)
@@ -1085,37 +1107,9 @@ function make(style::StructStyle, ::Type{T}, source) where {T}
                 return make(style, Base.nonnothingtype(T), source)
             end
         end
-        # for Union types like Union{T, Vector{T}} (after Nothing/Missing have been peeled),
-        # we can disambiguate by checking if source is arraylike;
-        # only applies when there's exactly one arraylike and one non-arraylike member
-        if T isa Union
-            types = Base.uniontypes(T)
-            arr_type = nothing
-            scalar_type = nothing
-            ambiguous = false
-            for t in types
-                if arraylike(style, t)
-                    # more than one arraylike type means we can't disambiguate
-                    if arr_type !== nothing
-                        ambiguous = true
-                        break
-                    end
-                    arr_type = t
-                else
-                    if scalar_type !== nothing
-                        ambiguous = true
-                        break
-                    end
-                    scalar_type = t
-                end
-            end
-            if !ambiguous && arr_type !== nothing && scalar_type !== nothing
-                if arraylike(style, source)
-                    return make(style, arr_type, source)
-                else
-                    return make(style, scalar_type, source)
-                end
-            end
+        if _isuniontype(T)
+            selected = _uniontype(style, T, source)
+            selected === nothing || return make(style, selected, source)
         end
     end
     if T <: Tuple
@@ -1467,8 +1461,14 @@ function makenoarg(style, y::T, source) where {T}
     return y, st
 end
 
+@inline _missingfield(::StructStyle, T::Type, key, defs) = get(defs, key, nothing)
+
 macro _v(i)
-    esc(:(isassigned(vals, $i) ? @inbounds(vals[$i])::fieldtype(T, $i) : get(defs, @inbounds(fsyms[$i]), nothing)::fieldtype(T, $i)))
+    esc(:(
+        isassigned(vals, $i) ?
+        @inbounds(vals[$i])::fieldtype(T, $i) :
+        _missingfield(style, T, @inbounds(fsyms[$i]), defs)::fieldtype(T, $i)
+    ))
 end
 
 @generated function _construct(::Type{T}, vals, style, fsyms) where {T}

--- a/test/construction.jl
+++ b/test/construction.jl
@@ -198,6 +198,9 @@ end
     end
 
     @testset "custom nullable dispatch" begin
+        source = Dict("a" => 1)
+        @test StructUtils.make(Union{Nothing,Vector{Any}}, source) == Any[1]
+        @test StructUtils.make(Union{Missing,Vector{Any}}, source) == Any[1]
         @test StructUtils.make(ChoiceHolder, (value=(x=2,),)) ==
             ChoiceHolder(ChosenValue(2))
         @test StructUtils.make(ChoiceHolder, (value=nothing,)) ==

--- a/test/lazily_initialized_fields.jl
+++ b/test/lazily_initialized_fields.jl
@@ -1,0 +1,142 @@
+using Test
+using StructUtils
+using LazilyInitializedFields
+
+struct LazyLeaf{T}
+    value::T
+end
+
+@lazy struct LazyFields{T}
+    required::T
+    @lazy scalar::Int
+    @lazy vector::Vector{T}
+    @lazy child::LazyLeaf{T}
+    @lazy optional::Union{Nothing,LazyLeaf{T}}
+    @lazy anyvalue::Any
+end
+
+struct LazyHolder{T}
+    child::LazyFields{T}
+end
+
+@lazy struct LazyCache{T}
+    id::Int
+    @lazy entry::LazyLeaf{T}
+end
+
+@lazy struct LazyNothing
+    @lazy value::Nothing
+end
+
+@lazy struct LazyMissing
+    @lazy value::Missing
+end
+
+@lazy struct LazyDefaults
+    required::Int
+    @lazy explicit::Int
+    @lazy implicit::String
+end
+
+StructUtils.fielddefaults(::StructUtils.StructStyle, ::Type{LazyDefaults}) =
+    (explicit=41,)
+
+struct LazyDefaultStyle <: StructUtils.StructStyle end
+StructUtils.fielddefaults(::LazyDefaultStyle, ::Type{LazyDefaults}) =
+    (explicit=42,)
+
+@testset "LazilyInitializedFields extension" begin
+    @testset "omitted fields use uninit" begin
+        value = StructUtils.make(LazyFields{Int}, Dict("required" => 1))
+
+        @test value.required == 1
+        for field in (:scalar, :vector, :child, :optional, :anyvalue)
+            @test LazilyInitializedFields.islazyfield(typeof(value), field)
+            @test getfield(value, field) === LazilyInitializedFields.uninit
+            @test !LazilyInitializedFields.isinit(value, field)
+        end
+    end
+
+    @testset "present fields use their logical types" begin
+        value = StructUtils.make(
+            LazyFields{Int},
+            Dict{String,Any}(
+                "required" => 1,
+                "scalar" => 2,
+                "vector" => Any[3, 4],
+                "child" => Dict("value" => 5),
+                "optional" => Dict("value" => 6),
+                "anyvalue" => Dict("untouched" => 7),
+            ),
+        )
+
+        @test value.required == 1
+        @test value.scalar == 2
+        @test value.vector == [3, 4]
+        @test value.child == LazyLeaf{Int}(5)
+        @test value.optional == LazyLeaf{Int}(6)
+        @test value.anyvalue == Dict("untouched" => 7)
+
+        @test (@inferred StructUtils.make(
+            LazyFields{Int},
+            (required=1, child=(value=2,), optional=nothing),
+        )) isa LazyFields{Int}
+
+        optional_nothing = StructUtils.make(
+            LazyFields{Int},
+            Dict("required" => 1, "optional" => nothing),
+        )
+        @test optional_nothing.optional === nothing
+
+        explicit_uninit = StructUtils.make(
+            LazyFields{Int},
+            Dict("required" => 1, "child" => LazilyInitializedFields.uninit),
+        )
+        @test getfield(explicit_uninit, :child) === LazilyInitializedFields.uninit
+    end
+
+    @testset "nested and direct union construction" begin
+        holder = StructUtils.make(
+            LazyHolder{Int},
+            Dict("child" => Dict("required" => 1)),
+        )
+        @test holder.child.required == 1
+        @test getfield(holder.child, :child) === LazilyInitializedFields.uninit
+
+        target = Union{typeof(LazilyInitializedFields.uninit),LazyLeaf{Int}}
+        @test StructUtils.make(target, Dict("value" => 2)) == LazyLeaf{Int}(2)
+        @test StructUtils.make(target, LazilyInitializedFields.uninit) ===
+              LazilyInitializedFields.uninit
+    end
+
+    @testset "unparameterized parent infers its parameter" begin
+        value = StructUtils.make(
+            LazyCache,
+            Dict("id" => 1, "entry" => Dict("value" => 2)),
+        )
+        @test value isa LazyCache{Int}
+        @test value.entry == LazyLeaf{Int}(2)
+    end
+
+    @testset "nullable-only fields reject non-null values" begin
+        @test StructUtils.make(LazyNothing, Dict("value" => nothing)).value === nothing
+        @test StructUtils.make(LazyMissing, Dict("value" => nothing)).value === missing
+        @test_throws ArgumentError StructUtils.make(LazyNothing, Dict("value" => 1))
+        @test_throws ArgumentError StructUtils.make(LazyMissing, Dict("value" => 1))
+    end
+
+    @testset "explicit defaults take precedence" begin
+        default = StructUtils.make(LazyDefaults, Dict("required" => 1))
+        @test default.explicit == 41
+        @test getfield(default, :implicit) === LazilyInitializedFields.uninit
+
+        styled = StructUtils.make(
+            LazyDefaults,
+            Dict("required" => 1),
+            LazyDefaultStyle(),
+        )
+        @test styled.explicit == 42
+        @test getfield(styled, :implicit) === LazilyInitializedFields.uninit
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -633,4 +633,5 @@ end
 
 end
 
+include(joinpath(dirname(pathof(StructUtils)), "../test/lazily_initialized_fields.jl"))
 include("trim_compile_tests.jl")


### PR DESCRIPTION
## Summary

- add a weak extension for LazilyInitializedFields
- initialize omitted lazy fields with `uninit`
- convert present lazy values through their logical field types
- support nested and inferred parametric lazy structs
- preserve explicit defaults and existing nullable-union behavior

## Root cause

LazilyInitializedFields stores a logical field `T` as `Union{Uninitialized,T}`. StructUtils used `nothing` for every omitted field and handled the physical union without knowing that `Uninitialized` is a sentinel. This caused type assertions for omitted fields and conversion failures for present nested structs.

The extension adds two narrow hooks. One supplies `uninit` only for omitted lazy fields. The other removes the sentinel before normal construction of a present value. The core hook supports `UnionAll` targets so constructors can infer parametric types.

## Compatibility

- no new exports
- LazilyInitializedFields 1.x remains supported
- generic nullable-union behavior remains unchanged
- explicit StructUtils field defaults take precedence
- outbound conversion behavior is unchanged

## Validation

- Julia 1.12.6 full suite passed, including 39 extension tests and 7 trim checks
- Julia 1.9.4 full applicable suite passed
- LazilyInitializedFields 1.0.0 focused suite passed 39/39
- documentation build and doctests passed
- independent standards and specification reviews were clean

Fixes #70

Co-authored by Codex